### PR TITLE
Add methods to`vsort!` and `quicksort!` to allow argsort

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '~1.8.0-0'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VectorizedStatistics"
 uuid = "3b853605-1c98-4422-8364-4bd93ee0529e"
 authors = ["C. Brenhin Keller", "Chris Elrod"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/src/VectorizedStatistics.jl
+++ b/src/VectorizedStatistics.jl
@@ -17,6 +17,7 @@ module VectorizedStatistics
 
     # Sorting-based statistics
     include("quicksort.jl")
+    include("argsort.jl")
     include("vsort.jl")
     include("vmedian.jl")
     include("vquantile.jl")

--- a/src/argsort.jl
+++ b/src/argsort.jl
@@ -52,7 +52,7 @@ function quicksort!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A),
                 I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
-                I[iₗ], I[iₘ], I[iᵤ] = A[iᵤ], A[iₗ], A[iₘ]
+                I[iₗ], I[iₘ], I[iᵤ] = I[iᵤ], I[iₗ], I[iₘ]
             end
         else
             if a <= c
@@ -125,7 +125,7 @@ function quicksortt!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A)
                 I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
-                I[iₗ], I[iₘ], I[iᵤ] = A[iᵤ], A[iₗ], A[iₘ]
+                I[iₗ], I[iₘ], I[iᵤ] = I[iᵤ], I[iₗ], I[iₘ]
             end
         else
             if a <= c

--- a/src/argsort.jl
+++ b/src/argsort.jl
@@ -49,7 +49,7 @@ function quicksort!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A),
         if a <= b
             if a <= c
                 A[iₘ], A[iᵤ] = c, b             # a ≤ c ≤ b
-                I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
+                I[iₘ], I[iᵤ] = I[iᵤ], I[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
                 I[iₗ], I[iₘ], I[iᵤ] = I[iᵤ], I[iₗ], I[iₘ]
@@ -122,7 +122,7 @@ function quicksortt!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A)
         if a <= b
             if a <= c
                 A[iₘ], A[iᵤ] = c, b             # a ≤ c ≤ b
-                I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
+                I[iₘ], I[iᵤ] = I[iᵤ], I[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
                 I[iₗ], I[iₘ], I[iᵤ] = I[iᵤ], I[iₗ], I[iₘ]

--- a/src/argsort.jl
+++ b/src/argsort.jl
@@ -1,55 +1,12 @@
-
-# Check for sortedness, assuming no NaNs
-@inline function issortedrange(A::AbstractArray, iₗ, iᵤ)
-    @inbounds for i = iₗ+1:iᵤ
-        if A[i-1] > A[i]
-            return false
-        end
-    end
-    return true
-end
-
-# Check for anti-sortedness, assuming no NaNs
-@inline function isantisortedrange(A::AbstractArray, iₗ, iᵤ)
-    @inbounds for i = iₗ+1:iᵤ
-        if A[i-1] < A[i]
-            return false
-        end
-    end
-    return true
-end
-
-# Reverse an array, faster than Base.reverse!
-@inline function vreverse!(A::AbstractArray, iₗ, iᵤ)
-    N = (iᵤ - iₗ) + 1
-    n = (N ÷ 2) - 1
-    if N < 32
-        @inbounds for i ∈ 0:n
-            𝔦ₗ, 𝔦ᵤ = iₗ+i, iᵤ-i
-            A[𝔦ₗ], A[𝔦ᵤ] = A[𝔦ᵤ], A[𝔦ₗ]
-        end
-    else
-        @turbo for i ∈ 0:n
-            𝔦ₗ = iₗ+i
-            𝔦ᵤ = iᵤ-i
-            l = A[𝔦ₗ]
-            u = A[𝔦ᵤ]
-            A[𝔦ₗ] = u
-            A[𝔦ᵤ] = l
-        end
-    end
-    return A
-end
-
 # Move all NaNs to the end of the array `A`
-function sortnans!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A))
+function sortnans!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A))
     # Count up NaNs
     Nₙₐₙ = 0
     @turbo for i = iₗ:iᵤ
         Nₙₐₙ += A[i] != A[i]
     end
     # If none, return early
-    Nₙₐₙ == 0 && return A, iₗ, iᵤ
+    Nₙₐₙ == 0 && return I, A, iₗ, iᵤ
 
     # Otherwise, swap all NaNs
     i = iₗ
@@ -63,63 +20,28 @@ function sortnans!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastinde
             end
             j <= i && break
             A[i], A[j] = A[j], A[i]
+            I[i], I[j] = I[j], I[i]
             j -= 1
         end
     end
-    return A, iₗ, iᵤ - Nₙₐₙ
+    return I, A, iₗ, iᵤ - Nₙₐₙ
 end
 # For integers, don't need to check for NaNs
-sortnans!(A::AbstractArray{<:Integer}, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A)) = A, iₗ, iᵤ
-
-# Partially sort `A` around the `k`th sorted element and return that element
-function quickselect!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A), k=(iₗ+iᵤ)÷2)
-    # Pick a pivot for partitioning
-    N = iᵤ - iₗ + 1
-    A[iₗ], A[k] = A[k], A[iₗ]
-    pivot = A[iₗ]
-
-    # Count up elements that must be moved to upper partition
-    Nᵤ = 0
-    @turbo for i = (iₗ+1):iᵤ
-        Nᵤ += A[i] >= pivot
-    end
-    Nₗ = N - Nᵤ
-
-    # Swap elements between upper and lower partitions
-    i = iₗ
-    j = iᵤ
-    @inbounds for n = 1:Nₗ-1
-        i = iₗ + n
-        if A[i] >= pivot
-            while A[j] >= pivot
-                j -= 1
-            end
-            j <= i && break
-            A[i], A[j] = A[j], A[i]
-            j -= 1
-        end
-    end
-    # Move pivot to the top of the lower partition
-    iₚ = iₗ + Nₗ - 1
-    A[iₗ], A[iₚ] = A[iₚ], A[iₗ]
-    # Recurse: select from partition containing k
-    (iₗ <= k < iₚ) && quickselect!(A, iₗ, iₚ, k)
-    (iₚ < k <= iᵤ) && quickselect!(A, iₚ+1, iᵤ, k)
-    return A[k]
-end
+sortnans!(I::AbstractArray, A::AbstractArray{<:Integer}, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A)) = I, A, iₗ, iᵤ
 
 
 # Sort `A`, assuming no NaNs
-function quicksort!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A))
+function quicksort!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A))
     if issortedrange(A, iₗ, iᵤ)
         # If already sorted, we're done here
-        return A
+        return I, A
     end
     # Otherwise, we have to sort
     N = iᵤ - iₗ + 1
     if isantisortedrange(A, iₗ, iᵤ)
         vreverse!(A, iₗ, iᵤ)
-        return A
+        vreverse!(I, iₗ, iᵤ)
+        return I, A
     elseif N == 3
         # We know we are neither sorted nor antisorted, so only four possibilities remain
         iₘ = iₗ + 1
@@ -127,21 +49,26 @@ function quicksort!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastind
         if a <= b
             if a <= c
                 A[iₘ], A[iᵤ] = c, b             # a ≤ c ≤ b
+                I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
+                I[iₗ], I[iₘ], I[iᵤ] = A[iᵤ], A[iₗ], A[iₘ]
             end
         else
             if a <= c
                 A[iₗ], A[iₘ] = b, a             # b ≤ a ≤ c
+                I[iₗ], I[iₘ] = I[iₘ], I[iₗ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = b, c, a   # b ≤ c ≤ a
+                I[iₗ], I[iₘ], I[iᵤ] = I[iₘ], I[iᵤ], I[iₗ]
             end
         end
-        return A
+        return I, A
     else
         # Pick a pivot for partitioning
         iₚ = iₗ + (N >> 2)
         A[iₗ], A[iₚ] = A[iₚ], A[iₗ]
+        I[iₗ], I[iₚ] = I[iₚ], I[iₗ]
         pivot = A[iₗ]
 
         # Count up elements that must be moved to upper partition
@@ -162,29 +89,32 @@ function quicksort!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastind
                 end
                 j <= i && break
                 A[i], A[j] = A[j], A[i]
+                I[i], I[j] = I[j], I[i]
                 j -= 1
             end
         end
         # Move pivot to the top of the lower partition
         iₚ = iₗ + Nₗ - 1
         A[iₗ], A[iₚ] = A[iₚ], A[iₗ]
+        I[iₗ], I[iₚ] = I[iₚ], I[iₗ]
         # Recurse: sort both upper and lower partitions
-        quicksort!(A, iₗ, iₚ)
-        quicksort!(A, iₚ+1, iᵤ)
+        quicksort!(I, A, iₗ, iₚ)
+        quicksort!(I, A, iₚ+1, iᵤ)
     end
 end
 
 # Sort `A`, assuming no NaNs, multithreaded
-function quicksortt!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A), level=1)
+function quicksortt!(I::AbstractArray, A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastindex(A), level=1)
     if issortedrange(A, iₗ, iᵤ)
         # If already sorted, we're done here
-        return A
+        return I, A
     end
     # Otherwise, we have to sort
     N = iᵤ - iₗ + 1
     if isantisortedrange(A, iₗ, iᵤ)
         vreverse!(A, iₗ, iᵤ)
-        return A
+        vreverse!(I, iₗ, iᵤ)
+        return I, A
     elseif N == 3
         # We know we are neither sorted nor antisorted, so only four possibilities remain
         iₘ = iₗ + 1
@@ -192,21 +122,26 @@ function quicksortt!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastin
         if a <= b
             if a <= c
                 A[iₘ], A[iᵤ] = c, b             # a ≤ c ≤ b
+                I[iₘ], I[iᵤ] = A[iᵤ], A[iₘ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = c, a, b   # c ≤ a ≤ b
+                I[iₗ], I[iₘ], I[iᵤ] = A[iᵤ], A[iₗ], A[iₘ]
             end
         else
             if a <= c
                 A[iₗ], A[iₘ] = b, a             # b ≤ a ≤ c
+                I[iₗ], I[iₘ] = I[iₘ], I[iₗ]
             else
                 A[iₗ], A[iₘ], A[iᵤ] = b, c, a   # b ≤ c ≤ a
+                I[iₗ], I[iₘ], I[iᵤ] = I[iₘ], I[iᵤ], I[iₗ]
             end
         end
-        return A
+        return I, A
     else
         # Pick a pivot for partitioning
         iₚ = iₗ + (N >> 2)
         A[iₗ], A[iₚ] = A[iₚ], A[iₗ]
+        I[iₗ], I[iₚ] = I[iₚ], I[iₗ]
         pivot = A[iₗ]
 
         # Count up elements that must be moved to upper partition
@@ -227,22 +162,24 @@ function quicksortt!(A::AbstractArray, iₗ::Int=firstindex(A), iᵤ::Int=lastin
                 end
                 j <= i && break
                 A[i], A[j] = A[j], A[i]
+                I[i], I[j] = I[j], I[i]
                 j -= 1
             end
         end
         # Move pivot to the top of the lower partition
         iₚ = iₗ + Nₗ - 1
         A[iₗ], A[iₚ] = A[iₚ], A[iₗ]
+        I[iₗ], I[iₚ] = I[iₚ], I[iₗ]
         # Recurse: sort both upper and lower partitions
         if level < 7
             @sync begin
-                Threads.@spawn quicksortt!(A, iₗ, iₚ, level+1)
-                Threads.@spawn quicksortt!(A, iₚ+1, iᵤ, level+1)
+                Threads.@spawn quicksortt!(I, A, iₗ, iₚ, level+1)
+                Threads.@spawn quicksortt!(I, A, iₚ+1, iᵤ, level+1)
             end
         else
-            quicksort!(A, iₗ, iₚ)
-            quicksort!(A, iₚ+1, iᵤ)
+            quicksort!(I, A, iₗ, iₚ)
+            quicksort!(I, A, iₚ+1, iᵤ)
         end
-        return A
+        return I, A
     end
 end

--- a/test/testSorting.jl
+++ b/test/testSorting.jl
@@ -9,24 +9,40 @@
 
     # Quicksort
     VectorizedStatistics.quicksort!(A)
-    sort!(B)
-    @test A == B
+    a = sort(A)
+    @test A == a
 
     A = rand(10_000)
-    B = sort(A)
+    a = sort(A)
     VectorizedStatistics.quicksort!(A)
-    @test A == B
+    @test A == a
+
+    A = rand(10_000)
+    a = sort(A)
+    I = collect(1:10_000)
+    i = sortperm(A)
+    VectorizedStatistics.quicksort!(I, A)
+    @test A == a
+    @test I == i
 
     # Multithreaded quicksort
     A = rand(100)
-    B = sort(A)
+    a = sort(A)
     VectorizedStatistics.quicksortt!(A)
-    @test A == B
+    @test A == a
 
     A = rand(10_000)
-    B = sort(A)
+    a = sort(A)
     VectorizedStatistics.quicksortt!(A)
-    @test A == B
+    @test A == a
+
+    A = rand(10_000)
+    a = sort(A)
+    I = collect(1:10_000)
+    i = sortperm(A)
+    VectorizedStatistics.quicksortt!(I, A)
+    @test A == a
+    @test I == i
 
     # Partialsort
     A = rand(101)
@@ -51,6 +67,10 @@
     A = rand(100)
     B = VectorizedStatistics.vsort(A, multithreaded=true)
     @test issorted(B)
+    Ix = sortperm(A)
+    I = collect(1:length(A))
+    vsort!(I, A)
+    @test Ix == I
 
     # Vsort, Int64
     A = rand(Int, 100)
@@ -59,6 +79,10 @@
     A = rand(Int, 100)
     B = VectorizedStatistics.vsort(A, multithreaded=true)
     @test issorted(B)
+    Ix = sortperm(A)
+    I = collect(1:length(A))
+    vsort!(I, A)
+    @test Ix == I
 
     # Vsort, dimensional cases
     A = rand(100,100)


### PR DESCRIPTION
This PR adds an optional two-argument form of `vsort!` (and, internally,`quicksort!`) wherein one may specify an additional array (`I`) to sort in-place via the same permutation as the array being actively sorted (`A`). 

This may be useful in several contexts. For example, if `I` is initialized with `collect(eachindex(A))`, the sorted `I` will be equal to `sortperm(A)` for the original `A`