### PR TITLE
Fix variable name typo in `vcov` and `vcor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VectorizedStatistics"
 uuid = "3b853605-1c98-4422-8364-4bd93ee0529e"
 authors = ["C. Brenhin Keller", "Chris Elrod"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/src/vcov.jl
+++ b/src/vcov.jl
@@ -61,7 +61,7 @@ If `corrected` is `true` as is the default, _Bessel's correction_ will be applie
 such that the sum is scaled by `n-1` rather than `n`, where `n = length(x)`.
 """
 function vcov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=:auto)
-    if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
+    if (multithreaded===:auto && length(X) > 4095) || multithreaded===true
         _vtcov(X, dims, corrected)
     else
         _vcov(X, dims, corrected)
@@ -183,7 +183,7 @@ along dimension `dims`. As `Statistics.cor`, but vectorized and (optionally)
 multithreaded.
 """
 function vcor(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=:auto)
-    if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
+    if (multithreaded===:auto && length(X) > 4095) || multithreaded===true
         _vtcor(X, dims, corrected)
     else
         _vcor(X, dims, corrected)


### PR DESCRIPTION
Should fix #17 