### PR TITLE
Make auto-multithreading opt-in

### DIFF
--- a/src/vcov.jl
+++ b/src/vcov.jl
@@ -24,7 +24,7 @@ end
 
 """
 ```julia
-vcov(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=:auto)
+vcov(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=false)
 ```
 Compute the covariance between the vectors `x` and `y`.
 As `Statistics.cov`, but vectorized and (optionally) multithreaded.
@@ -32,7 +32,7 @@ As `Statistics.cov`, but vectorized and (optionally) multithreaded.
 If `corrected` is `true` as is the default, _Bessel's correction_ will be applied,
 such that the sum is scaled by `n-1` rather than `n`, where `n = length(x)`.
 """
-function vcov(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=:auto)
+function vcov(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=false)
     # Check lengths
     nᵪ = length(x)
     nᵧ = length(y)
@@ -52,7 +52,7 @@ end
 
 """
 ```julia
-vcov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=:auto)
+vcov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=false)
 ```
 Compute the covariance matrix of the matrix `X`, along dimension `dims`.
 As `Statistics.cov`, but vectorized and (optionally) multithreaded.
@@ -60,7 +60,7 @@ As `Statistics.cov`, but vectorized and (optionally) multithreaded.
 If `corrected` is `true` as is the default, _Bessel's correction_ will be applied,
 such that the sum is scaled by `n-1` rather than `n`, where `n = length(x)`.
 """
-function vcov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=:auto)
+function vcov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=false)
     if (multithreaded===:auto && length(X) > 4095) || multithreaded===true
         _vtcov(X, dims, corrected)
     else
@@ -143,14 +143,14 @@ end
 
 """
 ```julia
-vcor(x::AbstractVector, y::AbstractVector, multithreaded=:auto)
+vcor(x::AbstractVector, y::AbstractVector, multithreaded=false)
 ```
 Compute the (Pearson's product-moment) correlation between the vectors `x` and `y`.
 As `Statistics.cor`, but vectorized and (optionally) multithreaded.
 
 Equivalent to `cov(x,y) / (std(x) * std(y))`.
 """
-function vcor(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=:auto)
+function vcor(x::AbstractVector, y::AbstractVector; corrected::Bool=true, multithreaded=false)
     # Check lengths
     nᵪ = length(x)
     nᵧ = length(y)
@@ -176,13 +176,13 @@ end
 
 """
 ```julia
-vcor(X::AbstractMatrix; dims::Int=1, multithreaded=:auto)
+vcor(X::AbstractMatrix; dims::Int=1, multithreaded=false)
 ```
 Compute the (Pearson's product-moment) correlation matrix of the matrix `X`,
 along dimension `dims`. As `Statistics.cor`, but vectorized and (optionally)
 multithreaded.
 """
-function vcor(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=:auto)
+function vcor(X::AbstractMatrix; dims::Int=1, corrected::Bool=true, multithreaded=false)
     if (multithreaded===:auto && length(X) > 4095) || multithreaded===true
         _vtcor(X, dims, corrected)
     else

--- a/src/vmean.jl
+++ b/src/vmean.jl
@@ -1,6 +1,6 @@
 """
 ```julia
-vmean(A; dims, multithreaded=:auto)
+vmean(A; dims, multithreaded=false)
 ```
 Compute the mean of all elements in `A`, optionally over dimensions specified by `dims`.
 As `Statistics.mean`, but vectorized and (optionally) multithreaded.
@@ -24,7 +24,7 @@ julia> vmean(A, dims=2)
  3.5
 ```
 """
-function vmean(A; dims=:, multithreaded=:auto)
+function vmean(A; dims=:, multithreaded=false)
     if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
         _vtmean(A, dims)
     else

--- a/src/vsort.jl
+++ b/src/vsort.jl
@@ -2,7 +2,7 @@
 
 """
 ```julia
-vsort(A; dims, multithreaded=:auto)
+vsort(A; dims, multithreaded=false)
 ```
 Return a sorted copy of the array `A`, optionally along dimensions specified by `dims`.
 
@@ -25,12 +25,12 @@ julia> vsort(A)
  3
  4
 """
-vsort(A; dims=:, multithreaded=:auto) = vsort!(copy(A), dims=dims, multithreaded=multithreaded)
+vsort(A; dims=:, multithreaded=false) = vsort!(copy(A), dims=dims, multithreaded=multithreaded)
 
 
 """
 ```julia
-vsort!([I], A; dims, multithreaded=:auto)
+vsort!([I], A; dims, multithreaded=false)
 ```
 Sort the array `A`, optionally along dimensions specified by `dims`.
 
@@ -57,14 +57,14 @@ julia> vsort!(A)
  4
 ```
 """
-function vsort!(A; dims=:, multithreaded=:auto)
+function vsort!(A; dims=:, multithreaded=false)
     if (multithreaded===:auto && length(A) > 16383) || multithreaded===true
         _vtsort!(A, dims)
     else
         _vsort!(A, dims)
     end
 end
-function vsort!(I, A; dims=:, multithreaded=:auto)
+function vsort!(I, A; dims=:, multithreaded=false)
     @assert eachindex(I) === eachindex(A)
     if (multithreaded===:auto && length(A) > 16383) || multithreaded===true
         _vtsort!(I, A, dims)
@@ -81,6 +81,7 @@ function _vsort!(A::AbstractArray, ::Colon)
     # Sort the non-NaN elements
     quicksort!(A, iₗ, iᵤ)
 end
+# Also permute `I` via the same permutation that sorts `A`
 function _vsort!(I, A::AbstractArray, ::Colon)
     @assert eachindex(I) === eachindex(A)
     # IF there are NaNs, move them all to the end of the array
@@ -88,7 +89,6 @@ function _vsort!(I, A::AbstractArray, ::Colon)
     # Sort the non-NaN elements
     quicksort!(I, A, iₗ, iᵤ)
 end
-
 
 ## --- as above, but multithreaded
 

--- a/src/vstd.jl
+++ b/src/vstd.jl
@@ -1,6 +1,6 @@
 """
 ```julia
-vstd(A; dims=:, mean=nothing, corrected=true, multithreaded=:auto)
+vstd(A; dims=:, mean=nothing, corrected=true, multithreaded=false)
 ```
 Compute the variance of all elements in `A`, optionally over dimensions specified by `dims`.
 As `Statistics.var`, but vectorized and (optionally) multithreaded.
@@ -28,7 +28,7 @@ julia> vstd(A, dims=2)
  0.7071067811865476
 ```
 """
-function vstd(A; dims=:, mean=nothing, corrected=true, multithreaded=:auto)
+function vstd(A; dims=:, mean=nothing, corrected=true, multithreaded=false)
     if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
         _vtstd(mean, corrected, A, dims)
     else

--- a/src/vsum.jl
+++ b/src/vsum.jl
@@ -1,6 +1,6 @@
 """
 ```julia
-vsum(A; dims, multithreaded=:auto)
+vsum(A; dims, multithreaded=false)
 ```
 Summate the values contained in `A`, optionally over dimensions specified by `dims`.
 As `Base.sum`, but vectorized and (optionally) multithreaded.
@@ -24,7 +24,7 @@ julia> vsum(A, dims=2)
  7
 ```
 """
-function vsum(A; dims=:, multithreaded=:auto)
+function vsum(A; dims=:, multithreaded=false)
     if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
         _vtsum(A, dims)
     else

--- a/src/vvar.jl
+++ b/src/vvar.jl
@@ -28,7 +28,7 @@ julia> vvar(A, dims=2)
  0.5
 ```
 """
-function vvar(A; dims=:, mean=nothing, corrected=true, multithreaded=:auto)
+function vvar(A; dims=:, mean=nothing, corrected=true, multithreaded=false)
     if (multithreaded===:auto && length(A) > 4095) || multithreaded===true
         _vtvar(mean, corrected, A, dims)
     else


### PR DESCRIPTION
Currently the default for all functions in this package that support multithreading is `multithreaded=:auto`, which tries to do the fastest thing possible (multithreading when the problem is above some size). 

While it is nice to just do the fastest thing possible, this is also a bit magical and can be a bit of a footgun (for example, causing allocations where otherwise there would be none).

This PR would switch the default to `multithreaded=false`; one could still of course choose `:auto` if you want the old behavior, but it would be opt-in.

This wouldn't be technically breaking, though if we do this we could consider making it a 0.x release since it is a nontrivial change and would not want to catch people by surprise. 

If anyone else who actively uses this package wants to chime in, input one way or the other would be much appreciated!