### PR TITLE
Improve type-stability in _vcor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.8'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
Fix #30 
The main change in this PR is to replace `Tuple`s by `Vector`s, as the size of an array will not be type-inferred in general. Also replace `1:m` by the corresponding array axis, which may help preserve static array sizes (aside from being safer when indexing into an array).

After this,
```julia
julia> using Statistics, VectorizedStatistics, BenchmarkTools

julia> a = rand(50, 50);

julia> @btime cor($a, dims=1);
  16.986 μs (12 allocations: 40.72 KiB)

julia> @btime vcor($a, dims=1);
  27.638 μs (4 allocations: 20.58 KiB)
```
Ideally, this should be even faster, but at least it's in the same ballpark now.

A further improvement may be to use aggressive constant propagation, which may help improve type-inference for static arrays, where each axis may have a different size. This isn't included in this PR.